### PR TITLE
Change default entity type to Article

### DIFF
--- a/cata-seo.php
+++ b/cata-seo.php
@@ -12,7 +12,7 @@
  * Description: Adds features related to search indexing and structured data.
  * Author:      Thought & Expression Co. <devjobs@thought.is>
  * Author URI:  https://thought.is
- * Version:     0.1.0
+ * Version:     0.1.1-beta1
  * License:     GPL v3 or later
  * License URI: http://www.gnu.org/licenses/gpl-3.0.txt
  */

--- a/cata-seo.php
+++ b/cata-seo.php
@@ -12,7 +12,7 @@
  * Description: Adds features related to search indexing and structured data.
  * Author:      Thought & Expression Co. <devjobs@thought.is>
  * Author URI:  https://thought.is
- * Version:     0.1.1-beta1
+ * Version:     0.1.1
  * License:     GPL v3 or later
  * License URI: http://www.gnu.org/licenses/gpl-3.0.txt
  */

--- a/includes/structured-data/class-structured-data.php
+++ b/includes/structured-data/class-structured-data.php
@@ -286,7 +286,7 @@ class Structured_Data {
 	 * @return string
 	 */
 	private static function get_type( int $post_id ): string {
-		return has_category( 'news', $post_id ) ? 'NewsArticle' : 'BlogPosting';
+		return has_category( 'news', $post_id ) ? 'NewsArticle' : 'Article';
 	}
 
 	/**


### PR DESCRIPTION
### Related Issues

- Resolves #3 

### What Was Accomplished

- Changed the default from BlogPosting to Article per editorial request.

### How It Was Tested
- [x] Local
- [x] Remote dev environment

### How To Test
- [x] Structured data is still produced for articles
- [x] It passes the Rich Results testing tool: https://search.google.com/test/rich-results
  - Note: I'm seeing a non-critical issue in the rich results tool because of a lack of timezones in our timestamps, I will make a separate issue for that.